### PR TITLE
Getting this plugin working again

### DIFF
--- a/ahpi.imgload.js
+++ b/ahpi.imgload.js
@@ -21,23 +21,27 @@
  * Chromium 5-6
  * Opera 9-10
  */
-(function ($) {
+(function ($, undefined) {
 	$.event.special.load = {
-		add: function (hollaback) {
+		add: function () {
+			var el = this;
 			if ( this.nodeType === 1 && this.nodeName.toUpperCase() === 'IMG' && this.src !== '' ) {
-				// Image is already complete, fire the hollaback (fixes browser issues were cached
+				// Image is already complete, fire the handler (fixes browser issues were cached
 				// images isn't triggering the load event)
-				if ( this.complete || this.readyState === 4 ) {
-					hollaback.handler.apply(this);
+				if ( this.complete || this.complete === undefined ) {
+					// Let jQuery finish binding the event handler
+					setTimeout(function () {
+						var src = el.src;
+						// webkit hack from http://groups.google.com/group/jquery-dev/browse_thread/thread/eee6ab7b2da50e1f
+						// data uri bypasses webkit log warning (thx doug jones)
+						el.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+						el.src = src;
+					}, 0);
 				}
 
 				// Check if data URI images is supported, fire 'error' event if not
 				else if ( this.readyState === 'uninitialized' && this.src.indexOf('data:') === 0 ) {
 					$(this).trigger('error');
-				}
-				
-				else {
-					$(this).bind('load', hollaback.handler);
 				}
 			}
 		}

--- a/ahpi.imgload.js
+++ b/ahpi.imgload.js
@@ -23,18 +23,27 @@
  */
 (function ($, undefined) {
 	$.event.special.load = {
-		add: function () {
-			var el = this;
+		add: function (handleObj) {
+			var el = this, datasrc = 'load-datasrc', old_handler;
+
 			if ( el.nodeType === 1 && el.nodeName.toUpperCase() === 'IMG' && el.src !== '' ) {
 				// Image is already complete, fire the handler (fixes browser issues were cached
 				// images isn't triggering the load event)
 				if ( el.complete || el.complete === undefined ) {
+					old_handler = handleObj.handler;
+					handleObj.handler = function () {
+						if (!$.data(el, datasrc)) {
+							old_handler.apply(el, arguments);
+						}
+					};
 					// Let jQuery finish binding the event handler
 					setTimeout(function () {
 						var src = el.src;
+						$.data(el, datasrc, true);
 						// webkit hack from http://groups.google.com/group/jquery-dev/browse_thread/thread/eee6ab7b2da50e1f
 						// data uri bypasses webkit log warning (thx doug jones)
 						el.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+						$.removeData(el, datasrc);
 						el.src = src;
 					}, 0);
 				}

--- a/ahpi.imgload.js
+++ b/ahpi.imgload.js
@@ -32,9 +32,11 @@
 				if ( el.complete || el.complete === undefined ) {
 					old_handler = handleObj.handler;
 					handleObj.handler = function () {
+						var ret;
 						if (!$.data(el, datasrc)) {
-							old_handler.apply(el, arguments);
+							ret = old_handler.apply(el, arguments);
 						}
+						return ret;
 					};
 					// Let jQuery finish binding the event handler
 					setTimeout(function () {

--- a/ahpi.imgload.js
+++ b/ahpi.imgload.js
@@ -1,6 +1,6 @@
 /*
  * Special event for image load events
- * Needed because some browsers does not trigger the event on cached images.
+ * Needed because some browsers does not trigger the event on already-loaded images.
 
  * MIT License
  * Paul Irish     | @paul_irish | www.paulirish.com
@@ -22,39 +22,36 @@
  * Opera 9-10
  */
 (function ($, undefined) {
-	$.event.special.load = {
-		add: function (handleObj) {
-			var el = this, flag = 'load-guid', old_handler;
+	$.each({
+		load: function (el) { return el.complete || el.complete === undefined; },
+		error: function (el) { return el.readyState === 'uninitialized' && el.src.indexOf('data:') === 0; }
+	}, function (eventName, isReady) {
+		$.event.special[eventName] = {
+			add: function (handleObj) {
+				var el = this, flag = eventName + '-guid', old_handler = handleObj.handler;
 
-			if ( el.nodeType === 1 && el.nodeName.toUpperCase() === 'IMG' && el.src !== '' ) {
-				// Image is already complete, fire the handler (fixes browser issues were cached
-				// images isn't triggering the load event)
-				if ( el.complete || el.complete === undefined ) {
-					old_handler = handleObj.handler;
+				if ( el.nodeType === 1 && el.nodeName.toUpperCase() === 'IMG' && el.src !== '' ) {
+					// Check if the image is already loaded or if data URI images are supported
+					// Trigger the event handler if necessary
+					if ( isReady(el) ) {
+						handleObj.handler = function () {
+							var guid = $.data(el, flag), ret;
+							if ( guid === old_handler.guid || guid === undefined ) {
+								ret = old_handler.apply(el, arguments);
+							}
+							return ret;
+						};
 
-					handleObj.handler = function () {
-						var guid = $.data(el, flag), ret;
-						if ( guid === old_handler.guid || guid === undefined ) {
-							ret = old_handler.apply(el, arguments);
-						}
-						return ret;
-					};
-
-					// Let jQuery finish binding the event handler
-					setTimeout(function () {
-						$(el)
-							.data(flag, old_handler.guid)
-							.trigger('load')
-							.removeData(flag);
-					}, 0);
-				}
-
-				// Check if data URI images is supported, fire 'error' event if not
-				else if ( el.readyState === 'uninitialized' && el.src.indexOf('data:') === 0 ) {
-					$(el).trigger('error');
+						// Let jQuery finish binding the event handler
+						setTimeout(function () {
+							$(el)
+								.data(flag, old_handler.guid)
+								.trigger(eventName)
+								.removeData(flag);
+						}, 0);
+					}
 				}
 			}
-
-		}
-	};
+		};
+	});
 }(jQuery));

--- a/ahpi.imgload.js
+++ b/ahpi.imgload.js
@@ -24,39 +24,28 @@
 (function ($, undefined) {
 	$.event.special.load = {
 		add: function (handleObj) {
-			var el = this, old_handler, noop, debounce, debounceSrc, debounceId;
+			var el = this, flag = 'load-guid', old_handler;
 
 			if ( el.nodeType === 1 && el.nodeName.toUpperCase() === 'IMG' && el.src !== '' ) {
 				// Image is already complete, fire the handler (fixes browser issues were cached
 				// images isn't triggering the load event)
 				if ( el.complete || el.complete === undefined ) {
 					old_handler = handleObj.handler;
-					noop = function () {};
-					debounce = function () { // Firefox 3.5-3.6 fires load twice for data: URI, so debounce
-						var ret;
-						if (el.src !== debounceSrc) {
-							debounceSrc = el.src;
+
+					handleObj.handler = function () {
+						var guid = $.data(el, flag), ret;
+						if ( guid === old_handler.guid || guid === undefined ) {
 							ret = old_handler.apply(el, arguments);
-							clearTimeout(debounceId);
-							debounceId = setTimeout(function () {
-								handleObj.handler = old_handler;
-								noop = debounce = null;
-							}, 500);
 						}
 						return ret;
 					};
-					noop.guid = debounce.guid = old_handler.guid;
-
-					handleObj.handler = noop;
 
 					// Let jQuery finish binding the event handler
 					setTimeout(function () {
-						var src = el.src;
-						// webkit hack from http://groups.google.com/group/jquery-dev/browse_thread/thread/eee6ab7b2da50e1f
-						// data uri bypasses webkit log warning (thx doug jones)
-						el.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
-						handleObj.handler = debounce;
-						el.src = src;
+						$(el)
+							.data(flag, old_handler.guid)
+							.trigger('load')
+							.removeData(flag);
 					}, 0);
 				}
 
@@ -65,6 +54,7 @@
 					$(el).trigger('error');
 				}
 			}
+
 		}
 	};
 }(jQuery));

--- a/ahpi.imgload.js
+++ b/ahpi.imgload.js
@@ -24,7 +24,7 @@
 (function ($) {
 	$.event.special.load = {
 		add: function (hollaback) {
-			if ( this.nodeType === 1 && this.tagName.toLowerCase() === 'img' && this.src !== '' ) {
+			if ( this.nodeType === 1 && this.nodeName.toUpperCase() === 'IMG' && this.src !== '' ) {
 				// Image is already complete, fire the hollaback (fixes browser issues were cached
 				// images isn't triggering the load event)
 				if ( this.complete || this.readyState === 4 ) {

--- a/ahpi.imgload.js
+++ b/ahpi.imgload.js
@@ -25,23 +25,23 @@
 	$.event.special.load = {
 		add: function () {
 			var el = this;
-			if ( this.nodeType === 1 && this.nodeName.toUpperCase() === 'IMG' && this.src !== '' ) {
+			if ( el.nodeType === 1 && el.nodeName.toUpperCase() === 'IMG' && el.src !== '' ) {
 				// Image is already complete, fire the handler (fixes browser issues were cached
 				// images isn't triggering the load event)
-				if ( this.complete || this.complete === undefined ) {
+				if ( el.complete || el.complete === undefined ) {
 					// Let jQuery finish binding the event handler
 					setTimeout(function () {
 						var src = el.src;
 						// webkit hack from http://groups.google.com/group/jquery-dev/browse_thread/thread/eee6ab7b2da50e1f
 						// data uri bypasses webkit log warning (thx doug jones)
-						el.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+						el.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 						el.src = src;
 					}, 0);
 				}
 
 				// Check if data URI images is supported, fire 'error' event if not
-				else if ( this.readyState === 'uninitialized' && this.src.indexOf('data:') === 0 ) {
-					$(this).trigger('error');
+				else if ( el.readyState === 'uninitialized' && el.src.indexOf('data:') === 0 ) {
+					$(el).trigger('error');
 				}
 			}
 		}

--- a/qunit/index.html
+++ b/qunit/index.html
@@ -10,6 +10,12 @@
 	<script src="../ahpi.imgload.js"></script>
 	<script src="qunit/qunit.js"></script>
 	<script>
+function log(msg) {
+	if (window.console && console.log) {
+		console.log(msg);
+	}
+}
+
 $(window).load(function () {
 	test("Image load event (Normal)", function () {
 
@@ -19,6 +25,7 @@ $(window).load(function () {
 			// NASA image URL from Dean Edwards (http://dean.edwards.name/my/busted.html)
 			.attr('src', 'http://www.nasa.gov/images/content/84857main_EC04-0325-23_lg.jpg?' + Math.random())
 			.bind('load', function () {
+				log('normal ' + this.src);
 				ok(true, "Load event fired");
 				start();
 			});
@@ -31,6 +38,7 @@ $(window).load(function () {
 
 		$('#cached')
 			.bind('load', function () {
+				log('cached ' + this.src);
 				ok(true, "Load event fired");
 				start();
 			});
@@ -43,13 +51,38 @@ $(window).load(function () {
 
 		$('#datauri')
 			.bind('error', function () {
+				log('data uri error ' + this.src);
 				ok(true, "Data URI not supported");
 				start();
 			})
 			.bind('load', function () {
+				log('data uri load ' + this.src);
 				ok(true, "Load event fired");
 				start();
 			});
+		stop();
+	});
+
+	test("Multiple load event handlers", function () {
+		var count = 0;
+
+		expect(1);
+
+		$('#multiple').bind('load', function () {
+			count++;
+			log('first handler ' + this.src);
+		});
+		setTimeout(function () {
+			$('#multiple').bind('load', function () {
+				count++;
+				log('second handler ' + this.src);
+			});
+		}, 2000);
+		setTimeout(function () {
+			equal(count, 2, "Previous load event handler not called when new handler is bound");
+			start();
+		}, 4000);
+
 		stop();
 	});
 });
@@ -63,6 +96,7 @@ $(window).load(function () {
 	<img id="normal" src="" height="240" width="300" />
 	<img id="cached" src="cached.gif" />
 	<img id="datauri" src="data:image/gif;base64,R0lGODdhGwAPAIAAAP///wAAACwAAAAAGwAPAAACN4SPqcvtD08IaIKJrclab+pdlDR+FViK50qq7Wu2XOjGJreEOmrDteqhCUed1E6R8RWTkaYzUgAAOw==" />
+	<img id="multiple" src="cached.gif" width="1" height="1" />
 	<a href="../ahpi.imgload.js">ahpi.imgload.js Source</a>
 </p>
 

--- a/qunit/index.html
+++ b/qunit/index.html
@@ -10,47 +10,49 @@
 	<script src="../ahpi.imgload.js"></script>
 	<script src="qunit/qunit.js"></script>
 	<script>
-(function () {
-
-var img = new Image();
-img.onerror = img.onload = function () { runTests(); };
-img.src = 'cached.gif';
-
-function runTests() {
-
+$(window).load(function () {
 	test("Image load event (Normal)", function () {
 
-		expect(2);
+		expect(1);
 
-		var $normal = $('#normal');
-		$normal.bind('load', function () { ok(true, "Load event fired"); });
-		$normal.unbind('load');
-		ok(true, "Load event unbound");
+		$('#normal')
+			// NASA image URL from Dean Edwards (http://dean.edwards.name/my/busted.html)
+			.attr('src', 'http://www.nasa.gov/images/content/84857main_EC04-0325-23_lg.jpg?' + Math.random())
+			.bind('load', function () {
+				ok(true, "Load event fired");
+				start();
+			});
+		stop();
 	});
 
 	test("Image load event (Cached)", function () {
 
-		expect(2);
+		expect(1);
 
-		var $cached = $('#cached').attr('src', 'cached.gif');
-		$cached.bind('load', function () { ok(true, "Load event fired"); });
-		$cached.unbind('load');
-		ok(true, 'Load event unbound');
+		$('#cached')
+			.bind('load', function () {
+				ok(true, "Load event fired");
+				start();
+			});
+		stop();
 	});
 
 	test("Image load event (Data URI)", function () {
 
-		expect(2);
+		expect(1);
 
-		var $datauri = $('#datauri');
-		$datauri.bind('error', function () { ok(true, "Data URI not supported"); });
-		$datauri.bind('load', function () { ok(true, "Load event fired"); });
-		$datauri.unbind('load');
-		ok(true, 'Load event unbound');
+		$('#datauri')
+			.bind('error', function () {
+				ok(true, "Data URI not supported");
+				start();
+			})
+			.bind('load', function () {
+				ok(true, "Load event fired");
+				start();
+			});
+		stop();
 	});
-}
-}());
-
+});
 	</script>
 
 </head>
@@ -58,8 +60,8 @@ function runTests() {
 <body>
 
 <p>
-	<img id="normal" src="normal.gif" />
-	<img id="cached" src="" />
+	<img id="normal" src="" height="240" width="300" />
+	<img id="cached" src="cached.gif" />
 	<img id="datauri" src="data:image/gif;base64,R0lGODdhGwAPAIAAAP///wAAACwAAAAAGwAPAAACN4SPqcvtD08IaIKJrclab+pdlDR+FViK50qq7Wu2XOjGJreEOmrDteqhCUed1E6R8RWTkaYzUgAAOw==" />
 	<a href="../ahpi.imgload.js">ahpi.imgload.js Source</a>
 </p>

--- a/qunit/index.html
+++ b/qunit/index.html
@@ -77,11 +77,11 @@ $(window).load(function () {
 				count++;
 				log('second handler ' + this.src);
 			});
-		}, 2000);
+		}, 1000);
 		setTimeout(function () {
 			equal(count, 2, "Previous load event handler not called when new handler is bound");
 			start();
-		}, 4000);
+		}, 2000);
 
 		stop();
 	});


### PR DESCRIPTION
Initially I wanted to reuse the approach from Paul Irish's gist (setting the image src to a data uri, then back again), but this was causing more side effects than I anticipated so I switched to a simpler .trigger('load'). If you'd rather have a cleaner list of commits to merge, I can redo the changes in another branch.

The biggest change to users of this plugin is that the event handler is called outside the bind call stack (using setTimeout). I've updated the test suite to reflect this.
